### PR TITLE
refactor: centralize models and task execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,39 @@
-# Python-generated files
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[oc]
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
 wheels/
-*.egg-info
+*.egg-info/
 
 # Virtual environments
+.env
 .venv
-.claude
+env/
+venv/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+
+# IDEs and editors
+.vscode/
+.idea/
+
+# Misc
+.DS_Store
+*.log
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Agent Debugger
+
+Agent Debugger provides a visual interface for planning and observing AI agent task execution.  
+Both Flask and FastAPI frontends are available and share a common execution engine.
+
+## Features
+- Task planning and cost estimation
+- Real-time WebSocket updates during execution
+- Pluggable tool architecture
+
+## Development
+```bash
+# Run Flask app
+uv run python app.py
+
+# Run FastAPI app
+uv run python run_fastapi.py
+```

--- a/agent_engine/executor.py
+++ b/agent_engine/executor.py
@@ -1,0 +1,136 @@
+"""Shared task execution helpers for web frameworks."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Awaitable, Callable
+
+
+# Type aliases for callbacks
+SyncSend = Callable[[str, dict], None]
+AsyncSend = Callable[[str, dict], Awaitable[None]]
+
+
+def _update_session(session: dict, result: dict) -> None:
+    session["total_tokens"] += result.get("input_tokens", 0) + result.get(
+        "output_tokens", 0
+    )
+    session["total_cost"] += result.get("cost", 0)
+    session["last_output"] = str(result.get("data", ""))[:500]
+
+
+def execute_agent_task(
+    agent_engine: Any,
+    tool_manager: Any,
+    task_id: str,
+    session: dict,
+    send: SyncSend,
+    sleep: Callable[[float], None] | None = None,
+) -> None:
+    """Execute a task synchronously.
+
+    Parameters
+    ----------
+    agent_engine: AgentDecisionEngine
+        Engine managing tasks and planning.
+    tool_manager: ToolManager
+        Manager used to execute tools.
+    task_id: str
+        Identifier for the task.
+    session: dict
+        Session dictionary storing progress.
+    send: callable
+        Callback used to emit events.
+    sleep: callable, optional
+        Sleep function allowing injection for testing.
+    """
+
+    if sleep is None:
+        import time
+
+        sleep = time.sleep
+
+    task = agent_engine.get_task(task_id)
+    if not task:
+        send("error", {"message": "任务不存在"})
+        return
+
+    task_plan = task.steps
+    for i, step in enumerate(task_plan):
+        step_data = {
+            "step": i + 1,
+            "total_steps": len(task_plan),
+            "tool": step.tool,
+            "description": step.description,
+        }
+        send("step_started", step_data)
+
+        input_data = task.description if i == 0 else session.get("last_output", "")
+        result = tool_manager.execute_tool(step.tool, input_data)
+        _update_session(session, result)
+
+        completion_data = {
+            "step": i + 1,
+            "total_steps": len(task_plan),
+            "total_tokens": result.get("input_tokens", 0)
+            + result.get("output_tokens", 0),
+            "cost": result.get("cost", 0),
+            "result": str(result.get("data", ""))[:200],
+            "success": result.get("success", False),
+        }
+        send("step_completed", completion_data)
+        sleep(1.5)
+
+    session["status"] = "completed"
+    session["completed_at"] = datetime.now()
+    send("task_completed", session)
+
+
+async def execute_agent_task_async(
+    agent_engine: Any,
+    tool_manager: Any,
+    task_id: str,
+    session: dict,
+    send: AsyncSend,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> None:
+    """Asynchronous task execution used by FastAPI."""
+
+    if sleep is None:
+        sleep = asyncio.sleep
+
+    task = agent_engine.get_task(task_id)
+    if not task:
+        await send("error", {"message": "任务不存在"})
+        return
+
+    task_plan = task.steps
+    for i, step in enumerate(task_plan):
+        step_data = {
+            "step": i + 1,
+            "total_steps": len(task_plan),
+            "tool": step.tool,
+            "description": step.description,
+        }
+        await send("step_started", step_data)
+
+        input_data = task.description if i == 0 else session.get("last_output", "")
+        result = tool_manager.execute_tool(step.tool, input_data)
+        _update_session(session, result)
+
+        completion_data = {
+            "step": i + 1,
+            "total_steps": len(task_plan),
+            "total_tokens": result.get("input_tokens", 0)
+            + result.get("output_tokens", 0),
+            "cost": result.get("cost", 0),
+            "result": str(result.get("data", ""))[:200],
+            "success": result.get("success", False),
+        }
+        await send("step_completed", completion_data)
+        await sleep(1.5)
+
+    session["status"] = "completed"
+    session["completed_at"] = datetime.now().isoformat()
+    await send("task_completed", session)

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class TaskRequest(BaseModel):
+    """Create task request."""
+
+    description: str
+    strategy: str = "balanced"
+    execution_mode: str = "static"
+
+
+class ExecutionRequest(BaseModel):
+    """Trigger task execution."""
+
+    execution_mode: str = "static"
+
+
+class TaskStep(BaseModel):
+    step_id: str
+    tool: str
+    description: str
+    status: str = "pending"
+
+
+class TaskResponse(BaseModel):
+    id: str
+    description: str
+    strategy: str
+    status: str
+    steps: List[TaskStep]
+    total_tokens: int = 0
+    total_cost: float = 0.0
+    created_at: datetime
+
+
+class CostEstimate(BaseModel):
+    total_tokens: int
+    total_cost: float
+    steps: int
+
+
+class ApiResponse(BaseModel):
+    success: bool
+    message: str
+    data: Optional[Dict[str, Any]] = None

--- a/run_fastapi.py
+++ b/run_fastapi.py
@@ -10,5 +10,5 @@ if __name__ == "__main__":
         host="0.0.0.0",
         port=8000,
         reload=True,
-        log_level="info"
+        log_level="info",
     )


### PR DESCRIPTION
## Summary
- remove duplicated pydantic models by adding shared `models/schemas.py`
- consolidate task execution logic in `agent_engine/executor.py`
- use shared helpers in Flask and FastAPI apps, add project README and improved .gitignore

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_688e1af8291c832292de630707b8fca2