### PR TITLE
Reorder Flask-related imports in app module

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
-import threading
-from datetime import datetime
-
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, render_template, request, jsonify
 from flask_socketio import SocketIO, join_room
-
+from datetime import datetime
+import threading
 from agent_engine.core import AgentDecisionEngine
 from agent_engine.executor import execute_agent_task
 from models.schemas import ApiResponse, TaskRequest


### PR DESCRIPTION
## Summary
- Reorder and group imports in `app.py` to include Flask, SocketIO, datetime, threading, and AgentDecisionEngine at the top of the file.

## Testing
- `python -m py_compile app.py`
- `pip install fastapi==0.116.1 flask==3.1.1 flask-cors==6.0.1 flask-socketio==5.5.1 openai==1.95.1 pydantic==2.11.7 python-multipart==0.0.20 requests==2.32.4 rich==14.0.0 uvicorn==0.35.0 pytest` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68a090b1a8548322b86465613fe45a63